### PR TITLE
Import creation functions

### DIFF
--- a/src/stactools/nrcan_landcover/__init__.py
+++ b/src/stactools/nrcan_landcover/__init__.py
@@ -1,4 +1,4 @@
-from stactools.nrcan_landcover.stac import create_item, create_collection
+from stactools.nrcan_landcover.stac import create_item, create_collection  # noqa: F401
 import stactools.core
 
 stactools.core.use_fsspec()

--- a/src/stactools/nrcan_landcover/__init__.py
+++ b/src/stactools/nrcan_landcover/__init__.py
@@ -1,3 +1,4 @@
+from stactools.nrcan_landcover.stac import create_item, create_collection
 import stactools.core
 
 stactools.core.use_fsspec()


### PR DESCRIPTION
This PR allows a python interpreter to see the commands used to create the STAC objects.

ex.
```python
>>> from stactools import nrcan_landcover
>>> nrcan_landcover.
nrcan_landcover.constants           nrcan_landcover.create_item(        nrcan_landcover.stac                
nrcan_landcover.create_collection(  nrcan_landcover.register_plugin(    nrcan_landcover.stactools
```