### PR TITLE
Add proj, file, and raster extension fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- STAC raster extension to STAC Items
+- STAC file extension to STAC Items
 - Colour map on COG
 - Ensure that the no_data value is set properly
 - STAC proj extension fields to STAC Items

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Colour map on COG
+- Ensure that the no_data value is set properly
 - STAC proj extension fields to STAC Items
 - Updated with contents of the template repo (a231a37275b0590e759d7114c4d6c7f685453c22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- STAC proj extension fields to STAC Items
 - Updated with contents of the template repo (a231a37275b0590e759d7114c4d6c7f685453c22)
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -2,18 +2,36 @@
 
 # stactools nrcan-landcover
 
+- Name: nrcan-landcover
+- Package: `stactools.nrcan-landcover`
+- PyPI: https://pypi.org/project/stactools-nrcan-landcover/
+- Owner: @sparkgeo
+- Dataset homepage: [NRCAN](https://www.nrcan.gc.ca/maps-tools-publications/satellite-imagery-air-photos/application-development/land-cover/21755)
+- STAC extensions used:
+  - [proj](https://github.com/stac-extensions/projection/)
+
 Collection of Land Cover products for Canada as produced by Natural Resources Canada using Landsat satellite imagery. This collection of cartographic products offers classified Land Cover of Canada at a 30 metre spatial resolution, updated on a 5 year basis.
 
 This land cover dataset is the Canadian contribution to the 30 metre spatial resolution 2015 Land Cover Map of North America, which is produced by Mexican, American and Canadian government institutions under a collaboration called the North American Land Change Monitoring System (NALCMS).
 
 ## Usage
 
-1. As a python module
+### Using the CLI
+
+```bash
+# STAC Collection
+stac nrcanlandcover create-collection -d "/path/to/directory"
+# Create a COG - creates /path/to/local_cog.tif
+stac nrcanlandcover create-cog -d "/path/to/directory" -s "/path/to/local.tif"
+# Create a STAC Item - creates /path/to/directory/local_cog.json
+stac nrcanlandcover create-item -d "/path/to/directory" -c "/path/to/local_cog.tif"
+```
+
+### As a python module
 
 ```python
 from stactools.nrcan_landcover.constants import JSONLD_HREF
 from stactools.nrcan_landcover import utils, cog, stac
-
 
 # Read metadata
 metadata = utils.get_metadata(JSONLD_HREF)
@@ -27,15 +45,4 @@ cog.create_cog("/path/to/local.tif", "/path/to/cog.tif")
 
 # Create a STAC Item
 stac.create_item(metadata, "/path/to/item.json", "/path/to/cog.tif")
-```
-
-2. Using the CLI
-
-```bash
-# STAC Collection
-stac nrcanlandcover create-collection -d "/path/to/directory"
-# Create a COG - creates /path/to/local_cog.tif
-stac nrcanlandcover create-cog -d "/path/to/directory" -s "/path/to/local.tif"
-# Create a STAC Item - creates /path/to/directory/local_cog.json
-stac nrcanlandcover create-item -d "/path/to/directory" -c "/path/to/local_cog.tif"
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 - Owner: @sparkgeo
 - Dataset homepage: [NRCAN](https://www.nrcan.gc.ca/maps-tools-publications/satellite-imagery-air-photos/application-development/land-cover/21755)
 - STAC extensions used:
+  - [file](https://github.com/stac-extensions/file/)
   - [proj](https://github.com/stac-extensions/projection/)
+  - [raster](https://github.com/stac-extensions/raster/)
 
 Collection of Land Cover products for Canada as produced by Natural Resources Canada using Landsat satellite imagery. This collection of cartographic products offers classified Land Cover of Canada at a 30 metre spatial resolution, updated on a 5 year basis.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -18,6 +18,9 @@ warn_return_any = True
 warn_unused_configs = True
 warn_unused_ignores = True
 
+[mypy-fsspec.*]
+ignore_missing_imports = True
+
 [mypy-rasterio.*]
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -18,5 +18,8 @@ warn_return_any = True
 warn_unused_configs = True
 warn_unused_ignores = True
 
+[mypy-rasterio.*]
+ignore_missing_imports = True
+
 [mypy-shapely.*]
 ignore_missing_imports = True

--- a/scripts/format
+++ b/scripts/format
@@ -19,6 +19,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
+        # Sort imports
+        isort --overwrite-in-place .
         # Code formatting
         yapf -ipr ${DIRS_TO_CHECK[@]}
     fi

--- a/scripts/lint
+++ b/scripts/lint
@@ -23,6 +23,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     else
         # Text formatting
         ec --exclude "$EC_EXCLUDE"
+        # Sort imports
+        isort --check .
         # Code formatting
         yapf -dpr ${DIRS_TO_CHECK[@]}
         # Lint

--- a/src/stactools/nrcan_landcover/__init__.py
+++ b/src/stactools/nrcan_landcover/__init__.py
@@ -1,7 +1,8 @@
 import stactools.core
 from stactools.cli import Registry
-from stactools.nrcan_landcover.stac import create_collection, create_item
+
 from stactools.nrcan_landcover.cog import create_cog
+from stactools.nrcan_landcover.stac import create_collection, create_item
 
 __all__ = [
     create_collection.__name__, create_item.__name__, create_cog.__name__

--- a/src/stactools/nrcan_landcover/cog.py
+++ b/src/stactools/nrcan_landcover/cog.py
@@ -81,6 +81,8 @@ def create_cog(
                 "predictor=yes",
                 "-co",
                 "OVERVIEWS=IGNORE_EXISTING",
+                "-a_nodata",
+                "0",
                 input_path,
                 output_path,
             ]

--- a/src/stactools/nrcan_landcover/cog.py
+++ b/src/stactools/nrcan_landcover/cog.py
@@ -5,9 +5,10 @@ from subprocess import CalledProcessError, check_output
 from tempfile import TemporaryDirectory
 from zipfile import ZipFile
 
+import rasterio
 import requests
 
-from stactools.nrcan_landcover.constants import JSONLD_HREF
+from stactools.nrcan_landcover.constants import COLOUR_MAP, JSONLD_HREF
 from stactools.nrcan_landcover.utils import get_metadata
 
 logger = logging.getLogger(__name__)
@@ -94,6 +95,8 @@ def create_cog(
                 raise
             finally:
                 logger.info(f"output: {str(output)}")
+            with rasterio.open(output_path, "r+") as dataset:
+                dataset.write_colormap(1, COLOUR_MAP)
 
     except Exception:
         logger.error("Failed to process {}".format(output_path))

--- a/src/stactools/nrcan_landcover/commands.py
+++ b/src/stactools/nrcan_landcover/commands.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import Optional
 
 import click
 
@@ -61,9 +62,9 @@ def create_nrcanlandcover_command(cli: click.Group) -> click.Command:
                   help="The output directory for the COG")
     @click.option("-s",
                   "--source",
-                  required=True,
+                  required=False,
                   help="Path to an input GeoTiff")
-    def create_cog_command(destination: str, source: str) -> None:
+    def create_cog_command(destination: str, source: Optional[str]) -> None:
         """Generate a COG from a GeoTiff. The COG will be saved in the desination
         with `_cog.tif` appended to the name.
 
@@ -74,10 +75,14 @@ def create_nrcanlandcover_command(cli: click.Group) -> click.Command:
         if not os.path.isdir(destination):
             raise IOError(f'Destination folder "{destination}" not found')
 
-        output_path = os.path.join(destination,
-                                   os.path.basename(source)[:-4] + "_cog.tif")
+        if source is None:
+            cog.download_create_cog(destination)
 
-        cog.create_cog(source, output_path)
+        else:
+            output_path = os.path.join(
+                destination,
+                os.path.basename(source)[:-4] + "_cog.tif")
+            cog.create_cog(source, output_path)
 
     @nrcanlandcover.command(
         "create-item",

--- a/src/stactools/nrcan_landcover/commands.py
+++ b/src/stactools/nrcan_landcover/commands.py
@@ -1,10 +1,9 @@
-import click
 import logging
 import os
 
-from stactools.nrcan_landcover import stac
-from stactools.nrcan_landcover import cog
-from stactools.nrcan_landcover import utils
+import click
+
+from stactools.nrcan_landcover import cog, stac, utils
 from stactools.nrcan_landcover.constants import JSONLD_HREF
 
 logger = logging.getLogger(__name__)

--- a/src/stactools/nrcan_landcover/constants.py
+++ b/src/stactools/nrcan_landcover/constants.py
@@ -26,3 +26,22 @@ NRCAN_PROVIDER = Provider(
 JSONLD_HREF = "https://open.canada.ca/data/en/dataset/4e615eae-b90c-420b-adee-2ca35896caf6.jsonld"
 
 NRCAN_FTP = "http://ftp.maps.canada.ca/pub/nrcan_rncan/Land-cover_Couverture-du-sol/canada-landcover_canada-couverture-du-sol/CanadaLandcover2015.zip"
+
+COLOUR_MAP = {
+    0: (0, 0, 0, 0),
+    1: (0, 61, 0, 255),
+    2: (147, 155, 112, 255),
+    5: (20, 140, 61, 255),
+    6: (91, 117, 43, 255),
+    8: (178, 137, 51, 255),
+    10: (224, 206, 137, 255),
+    11: (155, 117, 137, 255),
+    12: (186, 211, 84, 255),
+    13: (63, 137, 114, 255),
+    14: (107, 163, 137, 255),
+    15: (229, 173, 102, 255),
+    16: (168, 170, 173, 255),
+    17: (219, 33, 38, 155),
+    18: (76, 112, 163, 255),
+    19: (255, 249, 255, 255)
+}

--- a/src/stactools/nrcan_landcover/constants.py
+++ b/src/stactools/nrcan_landcover/constants.py
@@ -45,3 +45,21 @@ COLOUR_MAP = {
     18: (76, 112, 163, 255),
     19: (255, 249, 255, 255)
 }
+
+CLASSIFICATION_VALUES = {
+    1: "Temperate or sub-polar needleleaf forest",
+    2: "Sub-polar taiga needleleaf forest",
+    5: "Temperate or sub-polar broadleaf deciduous forest",
+    6: "Mixed forest",
+    8: "Temperate or sub-polar shrubland",
+    10: "Temperate or sub-polar grassland",
+    11: "Sub-polar or polar shrubland-lichen-moss",
+    12: "Sub-polar or polar grassland-lichen-moss",
+    13: "Sub-polar or polar barren-lichen-moss",
+    14: "Wetland",
+    15: "Cropland",
+    16: "Barren lands",
+    17: "Urban",
+    18: "Water",
+    19: "Snow and Ice",
+}

--- a/src/stactools/nrcan_landcover/constants.py
+++ b/src/stactools/nrcan_landcover/constants.py
@@ -1,8 +1,7 @@
 # flake8: noqa
 
 from pyproj import CRS
-from pystac import Provider, ProviderRole
-from pystac import Link
+from pystac import Link, Provider, ProviderRole
 
 LANDCOVER_ID = "nrcan-landcover"
 LANDCOVER_EPSG = 3978

--- a/src/stactools/nrcan_landcover/stac.py
+++ b/src/stactools/nrcan_landcover/stac.py
@@ -71,10 +71,11 @@ def create_item(metadata: Dict[str, Any],
 
     item_projection = ProjectionExtension.ext(item, add_if_missing=True)
     item_projection.epsg = LANDCOVER_EPSG
-    with rasterio.open(cog_href) as dataset:
-        item_projection.bbox = dataset.bounds
-        item_projection.transform = list(dataset.transform)
-        item_projection.shape = [dataset.height, dataset.width]
+    if cog_href is not None:
+        with rasterio.open(cog_href) as dataset:
+            item_projection.bbox = dataset.bounds
+            item_projection.transform = list(dataset.transform)
+            item_projection.shape = [dataset.height, dataset.width]
 
     # Create metadata asset
     item.add_asset(

--- a/src/stactools/nrcan_landcover/stac.py
+++ b/src/stactools/nrcan_landcover/stac.py
@@ -2,6 +2,7 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+import fsspec
 import pystac
 import pytz
 import rasterio
@@ -102,6 +103,10 @@ def create_item(metadata: Dict[str, Any],
             "summary": summary
         } for value, summary in CLASSIFICATION_VALUES.items()]
         cog_asset_file.values = mapping
+        with fsspec.open(cog_href) as file:
+            size = file.size
+            if size is not None:
+                cog_asset_file.size = size
 
     item.set_self_href(metadata_url)
 

--- a/src/stactools/nrcan_landcover/stac.py
+++ b/src/stactools/nrcan_landcover/stac.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 import pytz
 import logging
+import rasterio
 from pystac.extensions.projection import ProjectionExtension
 from stactools.nrcan_landcover.constants import (
     LANDCOVER_ID,
@@ -71,6 +72,10 @@ def create_item(metadata: Dict[str, Any],
 
     item_projection = ProjectionExtension.ext(item, add_if_missing=True)
     item_projection.epsg = LANDCOVER_EPSG
+    with rasterio.open(cog_href) as dataset:
+        item_projection.bbox = dataset.bounds
+        item_projection.transform = list(dataset.transform)
+        item_projection.shape = [dataset.height, dataset.width]
 
     # Create metadata asset
     item.add_asset(

--- a/src/stactools/nrcan_landcover/stac.py
+++ b/src/stactools/nrcan_landcover/stac.py
@@ -49,7 +49,7 @@ def create_item(metadata: Dict[str, Any],
     id = title.replace(" ", "-")
     geometry = metadata["geom_metadata"]
 
-    bbox = Polygon(geometry.get("coordinates")[0]).bounds
+    bbox = list(Polygon(geometry.get("coordinates")[0]).bounds)
     properties = {
         "title": title,
         "description": description,
@@ -73,7 +73,7 @@ def create_item(metadata: Dict[str, Any],
     item_projection.epsg = LANDCOVER_EPSG
     if cog_href is not None:
         with rasterio.open(cog_href) as dataset:
-            item_projection.bbox = dataset.bounds
+            item_projection.bbox = list(dataset.bounds)
             item_projection.transform = list(dataset.transform)
             item_projection.shape = [dataset.height, dataset.width]
 

--- a/src/stactools/nrcan_landcover/stac.py
+++ b/src/stactools/nrcan_landcover/stac.py
@@ -1,22 +1,18 @@
-from typing import Any, Dict, Optional
-from datetime import datetime
-from dateutil.relativedelta import relativedelta
-import pytz
 import logging
-import rasterio
-from pystac.extensions.projection import ProjectionExtension
-from stactools.nrcan_landcover.constants import (
-    LANDCOVER_ID,
-    LANDCOVER_EPSG,
-    LANDCOVER_TITLE,
-    DESCRIPTION,
-    NRCAN_PROVIDER,
-    LICENSE,
-    LICENSE_LINK,
-)
+from datetime import datetime
+from typing import Any, Dict, Optional
 
 import pystac
+import pytz
+import rasterio
+from dateutil.relativedelta import relativedelta
+from pystac.extensions.projection import ProjectionExtension
 from shapely.geometry import Polygon
+
+from stactools.nrcan_landcover.constants import (DESCRIPTION, LANDCOVER_EPSG,
+                                                 LANDCOVER_ID, LANDCOVER_TITLE,
+                                                 LICENSE, LICENSE_LINK,
+                                                 NRCAN_PROVIDER)
 
 logger = logging.getLogger(__name__)
 

--- a/src/stactools/nrcan_landcover/stac.py
+++ b/src/stactools/nrcan_landcover/stac.py
@@ -9,6 +9,8 @@ import rasterio
 from dateutil.relativedelta import relativedelta
 from pystac.extensions.file import FileExtension
 from pystac.extensions.projection import ProjectionExtension
+from pystac.extensions.raster import (DataType, RasterBand, RasterExtension,
+                                      Sampling)
 from shapely.geometry import Polygon
 
 from stactools.nrcan_landcover.constants import (CLASSIFICATION_VALUES,
@@ -97,6 +99,7 @@ def create_item(metadata: Dict[str, Any],
             title="Land cover of Canada COGs",
         )
         item.add_asset("landcover", cog_asset)
+        # File Extension
         cog_asset_file = FileExtension.ext(cog_asset, add_if_missing=True)
         # The following odd type annotation is needed
         mapping: List[Any] = [{
@@ -108,6 +111,14 @@ def create_item(metadata: Dict[str, Any],
             size = file.size
             if size is not None:
                 cog_asset_file.size = size
+        # Raster Extension
+        cog_asset_raster = RasterExtension.ext(cog_asset, add_if_missing=True)
+        cog_asset_raster.bands = [
+            RasterBand.create(nodata=0,
+                              sampling=Sampling.AREA,
+                              data_type=DataType.UINT8,
+                              spatial_resolution=30)
+        ]
 
     item.set_self_href(metadata_url)
 

--- a/src/stactools/nrcan_landcover/utils.py
+++ b/src/stactools/nrcan_landcover/utils.py
@@ -1,11 +1,11 @@
 import json
 import os
-import requests
 import shutil
-
 from tempfile import mkdtemp
 from typing import Any, Dict
 from zipfile import ZipFile
+
+import requests
 
 
 def _unzip_dir(zip_path: str, unzip_dir: str) -> str:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2,10 +2,9 @@ import os.path
 from tempfile import TemporaryDirectory
 
 import pystac
-
-from stactools.nrcan_landcover.commands import create_nrcanlandcover_command
 from stactools.testing import CliTestCase
 
+from stactools.nrcan_landcover.commands import create_nrcanlandcover_command
 from tests import test_data
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -51,9 +51,14 @@ class CreateCollectionTest(CliTestCase):
 
     def test_create_item(self):
         with TemporaryDirectory() as tmp_dir:
+            # Select a .tif data file
+            test_path = test_data.get_path("data-files")
+            cog_path = os.path.join(test_path, [
+                d for d in os.listdir(test_path) if d.lower().endswith(".tif")
+            ][0])
+
             result = self.run_command([
-                "nrcanlandcover", "create-item", "-d", tmp_dir, "-c",
-                "mock.tif"
+                "nrcanlandcover", "create-item", "-d", tmp_dir, "-c", cog_path
             ])
             self.assertEqual(result.exit_code,
                              0,

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1,12 +1,11 @@
 import os
-from tempfile import TemporaryDirectory
 import unittest
+from tempfile import TemporaryDirectory
 
 import pystac
 
+from stactools.nrcan_landcover import cog, stac, utils
 from stactools.nrcan_landcover.constants import JSONLD_HREF
-from stactools.nrcan_landcover import utils, cog, stac
-
 from tests import test_data
 
 

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -34,9 +34,15 @@ class StacTest(unittest.TestCase):
         with TemporaryDirectory() as tmp_dir:
             metadata = utils.get_metadata(JSONLD_HREF)
 
+            # Select a .tif data file
+            test_path = test_data.get_path("data-files")
+            cog_path = os.path.join(test_path, [
+                d for d in os.listdir(test_path) if d.lower().endswith(".tif")
+            ][0])
+
             # Create stac item
             json_path = os.path.join(tmp_dir, "test.json")
-            stac.create_item(metadata, json_path, "mock.tif")
+            stac.create_item(metadata, json_path, cog_path)
 
             jsons = [p for p in os.listdir(tmp_dir) if p.endswith(".json")]
             self.assertEqual(len(jsons), 1)

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -49,8 +49,26 @@ class StacTest(unittest.TestCase):
             item_path = os.path.join(tmp_dir, jsons[0])
 
             item = pystac.read_file(item_path)
+        asset = item.assets["landcover"]
 
-        item.validate()
+        # Projection Extension
+        assert "proj:epsg" in item.properties
+        assert "proj:bbox" in item.properties
+        assert "proj:transform" in item.properties
+        assert "proj:shape" in item.properties
+
+        # File Extension
+        assert "file:size" in asset.extra_fields
+        assert "file:values" in asset.extra_fields
+        assert len(asset.extra_fields["file:values"]) > 0
+        assert "raster:bands" in asset.extra_fields
+
+        # Raster Extension
+        assert len(asset.extra_fields["raster:bands"]) == 1
+        assert "nodata" in asset.extra_fields["raster:bands"][0]
+        assert "sampling" in asset.extra_fields["raster:bands"][0]
+        assert "data_type" in asset.extra_fields["raster:bands"][0]
+        assert "spatial_resolution" in asset.extra_fields["raster:bands"][0]
 
     def test_create_collection(self):
         with TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
Closes #10 

Adds fields from the STAC projection extension when generating STAC Items.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] ~Documentation has been updated to reflect changes, if applicable.~
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
