### PR TITLE
Fix saving and metadata URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Nothing.
+- Metadata Asset on STAC Collection.
 
 ### Deprecated
 
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Nothing
+- Metadata URL on STAC Item.
 
 ## [0.2.4]
 

--- a/src/stactools/nrcan_landcover/commands.py
+++ b/src/stactools/nrcan_landcover/commands.py
@@ -47,10 +47,9 @@ def create_nrcanlandcover_command(cli: click.Group) -> click.Command:
             Callable
         """
         metadata_dict = utils.get_metadata(metadata)
-
         output_path = os.path.join(destination, "collection.json")
-
-        stac.create_collection(metadata_dict, output_path)
+        collection = stac.create_collection(metadata_dict, output_path)
+        collection.save_object()
 
     @nrcanlandcover.command(
         "create-cog",
@@ -110,10 +109,9 @@ def create_nrcanlandcover_command(cli: click.Group) -> click.Command:
             metadata (str): url containing the NRCAN Landcover JSONLD metadata
         """
         jsonld_metadata = utils.get_metadata(metadata)
-
         output_path = os.path.join(destination,
                                    os.path.basename(cog)[:-4] + ".json")
-
-        stac.create_item(jsonld_metadata, output_path, cog)
+        item = stac.create_item(jsonld_metadata, output_path, cog)
+        item.save_object(dest_href=output_path)
 
     return nrcanlandcover

--- a/src/stactools/nrcan_landcover/commands.py
+++ b/src/stactools/nrcan_landcover/commands.py
@@ -48,8 +48,9 @@ def create_nrcanlandcover_command(cli: click.Group) -> click.Command:
         """
         metadata_dict = utils.get_metadata(metadata)
         output_path = os.path.join(destination, "collection.json")
-        collection = stac.create_collection(metadata_dict, output_path)
-        collection.save_object()
+        collection = stac.create_collection(metadata_dict, metadata)
+        collection.set_self_href(output_path)
+        collection.save_object(dest_href=output_path)
 
     @nrcanlandcover.command(
         "create-cog",
@@ -111,7 +112,8 @@ def create_nrcanlandcover_command(cli: click.Group) -> click.Command:
         jsonld_metadata = utils.get_metadata(metadata)
         output_path = os.path.join(destination,
                                    os.path.basename(cog)[:-4] + ".json")
-        item = stac.create_item(jsonld_metadata, output_path, cog)
+        item = stac.create_item(jsonld_metadata, metadata, cog)
+        item.set_self_href(output_path)
         item.save_object(dest_href=output_path)
 
     return nrcanlandcover

--- a/src/stactools/nrcan_landcover/stac.py
+++ b/src/stactools/nrcan_landcover/stac.py
@@ -14,21 +14,21 @@ from pystac.extensions.raster import (DataType, RasterBand, RasterExtension,
 from shapely.geometry import Polygon
 
 from stactools.nrcan_landcover.constants import (CLASSIFICATION_VALUES,
-                                                 DESCRIPTION, LANDCOVER_EPSG,
-                                                 LANDCOVER_ID, LANDCOVER_TITLE,
-                                                 LICENSE, LICENSE_LINK,
-                                                 NRCAN_PROVIDER)
+                                                 DESCRIPTION, JSONLD_HREF,
+                                                 LANDCOVER_EPSG, LANDCOVER_ID,
+                                                 LANDCOVER_TITLE, LICENSE,
+                                                 LICENSE_LINK, NRCAN_PROVIDER)
 
 logger = logging.getLogger(__name__)
 
 
 def create_item(metadata: Dict[str, Any],
-                metadata_url: str,
+                metadata_url: str = JSONLD_HREF,
                 cog_href: Optional[str] = None) -> pystac.Item:
     """Creates a STAC item for a Natural Resources Canada Land Cover dataset.
 
     Args:
-        metadata_url (str): Path to provider metadata.
+        metadata_url (str, optional): Path to provider metadata.
         cog_href (str, optional): Path to COG asset.
 
     Returns:
@@ -123,7 +123,7 @@ def create_item(metadata: Dict[str, Any],
 
 
 def create_collection(metadata: Dict[str, Any],
-                      metadata_url: str) -> pystac.Collection:
+                      metadata_url: str = JSONLD_HREF) -> pystac.Collection:
     """Create a STAC Collection using a jsonld file provided by NRCan
     and save it to a destination.
 
@@ -131,7 +131,7 @@ def create_collection(metadata: Dict[str, Any],
 
     Args:
         metadata (dict): metadata parsed from jsonld
-        metadata_url (str): Location to save the output STAC Collection json
+        metadata_url (str, optional): Location to save the output STAC Collection json
 
     Returns:
         pystac.Collection: pystac collection object

--- a/src/stactools/nrcan_landcover/stac.py
+++ b/src/stactools/nrcan_landcover/stac.py
@@ -119,9 +119,6 @@ def create_item(metadata: Dict[str, Any],
                               data_type=DataType.UINT8,
                               spatial_resolution=30)
         ]
-
-    item.set_self_href(metadata_url)
-
     return item
 
 
@@ -169,6 +166,15 @@ def create_collection(metadata: Dict[str, Any],
     )
     collection.add_link(LICENSE_LINK)
 
-    collection.set_self_href(metadata_url)
+    # Create metadata asset
+    collection.add_asset(
+        "metadata",
+        pystac.Asset(
+            href=metadata_url,
+            media_type=pystac.MediaType.JSON,
+            roles=["metadata"],
+            title="Land cover of Canada metadata",
+        ),
+    )
 
     return collection

--- a/src/stactools/nrcan_landcover/stac.py
+++ b/src/stactools/nrcan_landcover/stac.py
@@ -122,8 +122,6 @@ def create_item(metadata: Dict[str, Any],
 
     item.set_self_href(metadata_url)
 
-    item.save_object()
-
     return item
 
 
@@ -172,7 +170,5 @@ def create_collection(metadata: Dict[str, Any],
     collection.add_link(LICENSE_LINK)
 
     collection.set_self_href(metadata_url)
-
-    collection.save_object()
 
     return collection

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -41,7 +41,8 @@ class StacTest(unittest.TestCase):
 
             # Create stac item
             json_path = os.path.join(tmp_dir, "test.json")
-            stac.create_item(metadata, json_path, cog_path)
+            item = stac.create_item(metadata, json_path, cog_path)
+            item.save_object()
 
             jsons = [p for p in os.listdir(tmp_dir) if p.endswith(".json")]
             self.assertEqual(len(jsons), 1)
@@ -76,7 +77,8 @@ class StacTest(unittest.TestCase):
 
             # Create stac collection
             json_path = os.path.join(tmp_dir, "test.json")
-            stac.create_collection(metadata, json_path)
+            collection = stac.create_collection(metadata, json_path)
+            collection.save_object()
 
             jsons = [p for p in os.listdir(tmp_dir) if p.endswith(".json")]
             self.assertEqual(len(jsons), 1)

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -42,7 +42,8 @@ class StacTest(unittest.TestCase):
             # Create stac item
             json_path = os.path.join(tmp_dir, "test.json")
             item = stac.create_item(metadata, json_path, cog_path)
-            item.save_object()
+            item.set_self_href(json_path)
+            item.save_object(dest_href=json_path)
 
             jsons = [p for p in os.listdir(tmp_dir) if p.endswith(".json")]
             self.assertEqual(len(jsons), 1)
@@ -77,8 +78,9 @@ class StacTest(unittest.TestCase):
 
             # Create stac collection
             json_path = os.path.join(tmp_dir, "test.json")
-            collection = stac.create_collection(metadata, json_path)
-            collection.save_object()
+            collection = stac.create_collection(metadata, JSONLD_HREF)
+            collection.set_self_href(json_path)
+            collection.save_object(dest_href=json_path)
 
             jsons = [p for p in os.listdir(tmp_dir) if p.endswith(".json")]
             self.assertEqual(len(jsons), 1)


### PR DESCRIPTION
Saving should be handled in the command, not the `stac.py` functions.
Fix the metadata URL that is passed to the Item and Collection create functions.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- ~[ ] Documentation has been updated to reflect changes, if applicable.~
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
